### PR TITLE
Simplify build process under Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # jversion-x.h default is in repo
 # jversion.h is your local edit copy and is not in repo
 jsrc/jversion.h
+build
 
 # unix
 *.o
@@ -17,6 +18,7 @@ jsrc/jversion.h
 **/jconsole/**/
 **/jdll/**/
 **/tsdll/**/
+**/*~
 
 # windows - need to run with different versions of vs
 # following files are in repo for vs2013

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# jsource
+J engine source mirror
+
+At the time when I forked this project, building J was needlessly cumbersome and only built from hard-coded directories.
+My patch made the build much smoother without any hard-coded directories.
+
+The J team never responded to my pull request so I keep this here so I don't lose my build work.

--- a/make/build_all.sh
+++ b/make/build_all.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # build all binaries
-cd ~
-. jvars.sh
 
 $jmake/install.sh
 

--- a/make/build_jconsole.sh
+++ b/make/build_jconsole.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # $1 is j32 or j64
-cd ~
-. jvars.sh
 
 common=" -fPIC -O1 -Wextra -Wno-unused-parameter "
 

--- a/make/build_jconsolewin.sh
+++ b/make/build_jconsolewin.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # $1 is j32 or j64
-cd ~
-. jvars.sh
 
 common=" -fPIC -O1 -Wextra "
 

--- a/make/build_jdll.sh
+++ b/make/build_jdll.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # $1 is j32 or j64
-cd ~
-. jvars.sh
 
 # gcc 5 vs 4 - killing off linux asm routines (overflow detection)
 # new fast code uses builtins not available in gcc 4

--- a/make/build_libj.sh
+++ b/make/build_libj.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # $1 is j32 or j64
-cd ~
-. jvars.sh
 
 # gcc 5 vs 4 - killing off linux asm routines (overflow detection)
 # new fast code uses builtins not available in gcc 4

--- a/make/build_tsdll.sh
+++ b/make/build_tsdll.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # $1 is j32 or j64
-cd ~
-. jvars.sh
 
 common=" -fPIC -O1 -Werror -Wextra -Wno-unused-parameter"
 

--- a/make/domake.sh
+++ b/make/domake.sh
@@ -3,9 +3,6 @@
 # run by build_jconsole and build_libj
 # $1 is j32 or j64
 
-cd ~
-. jvars.sh
-
 echo $TARGET
 echo $COMPILE
 echo $LINK

--- a/make/domakewin.sh
+++ b/make/domakewin.sh
@@ -3,9 +3,6 @@
 # run by build_jconsole and build_libj
 # $1 is j32 or j64
 
-cd ~
-. jvars.sh
-
 echo $TARGET
 echo $COMPILE
 echo $LINK

--- a/make/install-opt.sh
+++ b/make/install-opt.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# install jbld folders - new install or a reinstall
+
+OPT=/opt/J
+ROOT=..
+
+rm -fr $OPT
+mkdir $OPT
+mkdir $OPT/j32
+mkdir $OPT/j64
+cp -r $ROOT/build/j32/* $OPT/j32
+cp -r $ROOT/build/j64/* $OPT/j64
+cat <<EOF >$OPT/j32/bin/jhs
+#!/bin/sh
+jconsole ~addons/ide/jhs/core.ijs -js " init_jhs_'' "
+EOF
+cat <<EOF >$OPT/j64/bin/jhs
+#!/bin/sh
+jconsole ~addons/ide/jhs/core.ijs -js " init_jhs_'' "
+EOF
+chmod +x $OPT/j32/bin/jhs $OPT/j64/bin/jhs
+
+echo "install complete"
+echo ""
+echo "$ROOT/license.txt"
+
+cat $ROOT/license.txt
+exit 0
+

--- a/make/install.sh
+++ b/make/install.sh
@@ -1,15 +1,6 @@
 #!/bin/bash
 # install jbld folders - new install or a reinstall
 
-cd ~
-if [ ! -f jvars.sh ]; then
- echo "~/jvars.sh must exist"
- exit 1
-fi
-
-cd ~
-. jvars.sh
-
 rm -f -r $jbld
 mkdir $jbld
 mkdir $jbld/j32

--- a/make/jvars.sh
+++ b/make/jvars.sh
@@ -1,8 +1,10 @@
 # source shell script (read with . jvars.sh) so stuff is easy to find
 
 # edit following if your install is not standard 
-jgit=~/gitdev/jsource # git jsource folder
-jbld=~/jbld           # test libraries and binaries will be put here
+cd ..
+jgit=$(pwd)
+cd make
+jbld=$jgit/build
 
 # edit platform to build - linux darwin raspberry
 jplatform=linux

--- a/make/make.sh
+++ b/make/make.sh
@@ -1,0 +1,26 @@
+#
+
+export jplatform=`uname  |awk '{print tolower($0)}'`
+
+cd ../jsrc
+if [ ! -f jversion.h ]; then
+    sed -e "s/jplatform.*unknown/jplatform  \"$jplatform/" jversion-x.h >$$
+    sed -e "s/jbuilder.*unknown/jbuilder   \"`uname -n`/" $$ >jversion.h
+    rm $$
+fi
+
+cd ..
+export jgit=$(pwd)
+cd make
+export jbld=$jgit/build
+
+export j32=$jbld/j32/bin/jconsole
+export j64=$jbld/j64/bin/jconsole
+export j64avx="$jbld/j64/bin/jconsole -lib libjavx.so"
+export jmake=$jgit/make
+
+$jmake/install.sh
+$jmake/clean.sh
+
+$jmake/build_all.sh
+$jmake/release.sh

--- a/make/make.txt
+++ b/make/make.txt
@@ -1,57 +1,40 @@
-how to build/test j32/64 for linux/darwin/raspberry/...
+How to build/test j32/64 for linux/darwin/raspberry/...
 
-$jplatform (set by jvars.sh) determines compiler/link flags
-
-$jplatform is a simple name that implies OS and hardware
-
-linux     implies intel
-darwin    implies intel
-raspberry implies linux/arm/little-endian
-
-to support linux on arm big-endian you need to add support in
-build_jconsole.sh,... for a new platform (perhaps named linux_arm_be)
+Note:  on a 64 bit linux system, the following packages will be needed:
+	gcc-multilib
+	libedit-dev
 
 **************************************************************************
-# commands are assumed to run in ~ and depend on jvars.sh
+# In what follows $ROOT is the root directory of your J project
 
+cd $ROOT/make
 # make sure shell scripts are executable
-chmod +x gitdev/jsource/make/*.sh
+chmod +x *.sh
 
-# copy jvars.sh to ~ (for finding things)
-cp gitdev/jsource/make/jvars.sh .
-cat jvars.sh
-
-# read jvars.sh and edit as appropriate - other steps depend on jvars.sh
+# Edit jplatform in file make.sh
 # !!! edit platform to be appropriate for the system doing the builds !!!
 # valid platforms are: linux darwin raspberry
 
-# create clean build folders
-. jvars.sh
-$jmake/install.sh
+./make.sh
 
-# ensure proper jsrc/jversion.h (jversion-x.h template)
+# The above line builds the system into the $ROOT/build directory
 
-# !!! makefiles do not have h file dependencies !!!
-# after h file changes, run clean.sh to rm all *.o fles for clean build
-$jmake/clean.sh
+# To install to /opt do:
 
-# build j64 binaries
-$jmake/build_jconsole.sh j64
-$jmake/build_libj.sh     j64
-$jmake/build_tsdll.sh    j64
+sudo ./install-opt.sh
 
-# test j64
-$j64
-   load'gitdev/jsource/test/tsu.ijs'
-...
-   RUN ddall
+# Set path to access J
 
-# build/test j32 binaries the same way (j32 instead of j64)
+export PATH=/opt/J/j64/bin:$PATH
 
-# build everything from scratch
-$jmake/build_all.sh
+# To run jconsole
 
-# release clean builds to the repo release folder
-. jvars.sh
-$jmake/release.sh
+jconsole
 
+# To run the browser based IDE
+
+jhs
+
+# then go to the following URL on your browser:
+
+http://127.0.0.1:65001/jijx

--- a/make/release.sh
+++ b/make/release.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # copy binaries to release folder
-cd ~
-. jvars.sh
 
 mkdir -p $jgit/release/$jplatform/j32
 rm    -f $jgit/release/$jplatform/j32/*

--- a/overview.txt
+++ b/overview.txt
@@ -1,3 +1,5 @@
+For unix builds, see make/make.txt rather than this file.
+
 examples assume ~/gitdev/jsource and builds in ~/jbld
 
 put jsource anywhere (adjust examples etc.)


### PR DESCRIPTION
This patch significantly simplifies the build process under Linux.  Additionally, the source no longer needs to be in any special directory, and no environment variables need to be set.  It now builds in-place - no other directory trees.