### PR TITLE
Fix 2!:2 related reference count error

### DIFF
--- a/jsrc/xo.c
+++ b/jsrc/xo.c
@@ -106,7 +106,7 @@ F1(jtjopen){A z;I h;
 
 B jtadd2(J jt,F f1,F f2,C*cmd){A c,x;
  if(f1==NULL) {jt->fopn+=2;R 1;};
- GATV(c,LIT,1+strlen(cmd),1,0);MC(CAV(c)+1,cmd,AN(c)-1);cmd=CAV(c);
+ GATV(c,LIT,1+strlen(cmd),1,0);RZ(ras(c));MC(CAV(c)+1,cmd,AN(c)-1);cmd=CAV(c);
  if(jt->fopn+1>=AN(jt->fopf)){RZ(jt->fopa=ext(1,jt->fopa)); RZ(jt->fopf=ext(1,jt->fopf));}
  *cmd='<';x=cstr(cmd); RZ(ras(x)); RZ(*(jt->fopn+AAV(jt->fopa)  )=x); RZ(*(jt->fopn+IAV(jt->fopf)  )=(I)f1);
  *cmd='>';x=cstr(cmd); RZ(ras(x)); RZ(*(jt->fopn+AAV(jt->fopa)+1)=x); RZ(*(jt->fopn+IAV(jt->fopf)+1)=(I)f2);


### PR DESCRIPTION
The 2!:2 foreign conjunction is currently broken on Linux.
The jthostio function calls add2 which creates a literal
string, copies the command line into it, and updates
the internal list of open files to contain the file handle
and command line.

The existing code does not increment the reference count on
the string literal. When it is later unreferenced in add2
memory instability results. This effects can be seen as random
segfaults, parser errors and 1!:20 crashing after 2!:2 is used.

The fix here is to bump the reference count so it is correctly
handled when the reverse is done at the end of the function.

Although this fixes 2!:2 and 1!:20 the 1!:1 read call will still
fail on the returned file handle due to issues there where it
attempts to seek on the file handle, but pipes don't support
seeking. The handles can be used from FFI calls to fread however.

Code that demonstrates the instability on my system, before this commit is applied:

      2!:2 '/bin/ls'
    10554 93976423924960 93976423925520
      1 2
     Segmentation fault (core dumped)

After this commit is applied the code example above works.