### PR TITLE
Update make.txt to take care of small bugs

### DIFF
--- a/make/make.txt
+++ b/make/make.txt
@@ -8,6 +8,8 @@ linux     implies intel
 darwin    implies intel
 raspberry implies linux/arm
 
+NOTE: This uses clang/llvm. If on Debian you'll also need libedit-dev (libedit-devel on Fedora)
+
 **************************************************************************
 # commands are assumed to run in ~ and depend on jvars.sh
 
@@ -22,7 +24,7 @@ cat jvars.sh
 
 # create clean build folders and build all binaries
 . jvars.sh
-$jmake/buld_all.sh
+$jmake/build_all.sh
 
 # create clean build folders
 . jvars.sh


### PR DESCRIPTION
1. It's `$jmake/build_all.sh`, not `$jmake/buld_all.sh`
1. I had some issues getting this up because clang uses the `-ledit` flag, which requires you to add an additional package on Linux.