### PR TITLE
Add Jassoc API to directly associate a name to A

### DIFF
--- a/dllsrc/jdll.def
+++ b/dllsrc/jdll.def
@@ -28,3 +28,4 @@ EXPORTS
                 JInt64R             @28
                 JGetR               @29
                 JSMX                @30
+                Jassoc              @31

--- a/dllsrc/jdll2.def
+++ b/dllsrc/jdll2.def
@@ -14,4 +14,4 @@ EXPORTS
                 JSetA               @27
                 JGetR               @29
                 JSMX                @30
-                
+                Jassoc              @31

--- a/jsrc/io.c
+++ b/jsrc/io.c
@@ -760,6 +760,20 @@ static int setterm(JS jt, C* name, I* jtype, I* jrank, I* jshape, I* jdata)
  return jm->jerr;
 }
 
+int _stdcall Jassoc(JS jt, C* name, A w)
+{
+ SETJTJM(jt,jt,jm)
+ int er;
+ char gn[256];
+ if(FUNC&AT(w)) return EVDOMAIN;
+ // validate name
+ if(strlen(name) >= sizeof(gn)) return EVILNAME;
+ if(valid(name, gn)) return EVILNAME;
+ jm->jerr=0;
+ jtjset(jm,gn, w);
+ return jm->jerr;
+}
+
 int _stdcall JSetM(JS jt, C* name, I* jtype, I* jrank, I* jshape, I* jdata)
 {
  SETJTJM(jt,jt,jm)

--- a/jsrc/jlib.h
+++ b/jsrc/jlib.h
@@ -7,12 +7,13 @@
 typedef void* JS
 #endif
 
-CDPROC JS _stdcall JInit(void);                         /* init instance */
+CDPROC JS _stdcall JInit(void);                     /* init instance */
 CDPROC void _stdcall JSM(JS jt, void*callbacks[]);  /* set callbacks */
 CDPROC void _stdcall JSMX(JS jt, void*, void*, void*, void*, I);
 CDPROC int _stdcall JDo(JS jt,C*);                  /* run sentence */
 CDPROC C* _stdcall JGetLocale(JS jt);               /* get locale */
-CDPROC A _stdcall Jga(JS jt, I t, I n, I r, I*s);
+CDPROC A _stdcall Jga(JS jt, I t, I n, I r, I*s);   /* allocate array */
+CDPROC int _stdcall Jassoc(JS jt, C* name, A w);    /* associate name to array */
 CDPROC int _stdcall JFree(JS jt);                   /* free instance */
 CDPROC A _stdcall JGetA(JS jt,I n,C* name);         /* get 3!:1 from name */
 CDPROC C* _stdcall JGetR(JS jt);                    /* get capture */


### PR DESCRIPTION
Abstract
---------

This PR proposes a new DLL API, `Jassoc`, which allows binding an object of `A` directly to a name in J.

Motivation
------------
J ships `j.dll` and `libj.so` with different capabilities if the former is built with `OLECOM`. Only in COM interface, J.dll is able to put structural data in J using an array of boxes. In COM, the structural data is a multi-dimensional array of `VARIANT`. But to the other language bindings, this is not possible, because `JSetM` doesn't allow it. This is different from `JGetM` which does allow accessing arrays of `A` from the DLL interface.

In order to exchange Python's `tuple` or `np.array` of `Object` with J, we need to put arrays of `A` into J using the non-COM, dynamic library interface.

DIscussion
------------

One option might be adding this functionality to the existing `JSetM`. But `JSetM` assumes that we are not copying data from `A` back to J. Meanwhile,

1. Processing structural data ends up having recursive calls, and the natural outcome of that call is `A`.
2. We don't want to allocate an array of `A` in a foreign language's heap just for the purpose of fitting into `JSetM`'s interface, because no foreign language can make use of `A`.

In a word, we want to allocate `A` on J's heap using `Jga`, update its content, and give that array a name in J.

Doing so has an extra desired property. In the past, a foreign language must provide data in `int64_t` or `double`, because `JSetM` won't be able to copy from a contiguous memory of `int32_t` or `float`. But if we can assign `A` back to J, we can form `A` first, and do the copying outside. This copy doesn't need to be `memcpy`.

Implementation
-----------------
The patch originates from a change on an older branch that has no j903 multithreaded areas. That change worked well, but the patch in this PR is rebased accordingly and provided as-is. We haven't tested it because J upstream is not CMake-enabled.