### PR TITLE
Openbsd arm64 and amd64 support

### DIFF
--- a/benchmark/avx.ijs
+++ b/benchmark/avx.ijs
@@ -43,6 +43,8 @@ case. 'Win' do.
  dltb;1{<;._2 CR-.~shell'wmic cpu get name'
 case. 'Darwin' do.
  shell'sysctl -n machdep.cpu.brand_string'
+case. 'OpenBSD' do.
+ shell'sysctl -n machdep.cpuvendor'
 end. 
 )
 

--- a/jlibrary/system/config/base.cfg
+++ b/jlibrary/system/config/base.cfg
@@ -82,7 +82,7 @@ case. 'Darwin' do.
   Editor_nox=: ''
   TermEmu=: ''
   TermEmu_nox=: ''
-case. 'Linux' do.
+case. 'Linux';'OpenBSD' do.
   BoxForm=: 0
   Browser=: ''
   Browser_nox=: ''

--- a/jlibrary/system/main/regex.ijs
+++ b/jlibrary/system/main/regex.ijs
@@ -179,7 +179,7 @@ NB. pcre2 library is in bin or tools/regex
 select. UNAME
 case. 'Win' do. t=. 'jpcre2.dll'
 case. 'Darwin' do. t=. 'libjpcre2.dylib'
-case. 'Linux' do. t=. 'libjpcre2.so'
+case. 'Linux';'OpenBSD' do. t=. 'libjpcre2.so'
 case. 'Android' do. t=. 'libjpcre2.so'
 end.
 

--- a/jlibrary/system/util/pacman.ijs
+++ b/jlibrary/system/util/pacman.ijs
@@ -403,7 +403,7 @@ if. IFUNIX do.
     'file dir'=. y
     if. (i.0 0) -: tar 'x';file;dir do. e=. '' end.
   else.
-    e=. shellcmd 'tar ',((IFIOS+:UNAME-:'Android')#(('Darwin'-:UNAME){::'--no-same-owner --no-same-permissions';'-o -p')),' -xzf ',file,' -C ',dir
+    e=. shellcmd 'tar ',((IFIOS+:UNAME-:'Android')#((('Darwin'&-:+.'OpenBSD'&-:)UNAME){::'--no-same-owner --no-same-permissions';'-o -p')),' -xzf ',file,' -C ',dir
   end.
   if. ('/usr/'-:5{.dir-.'"') *. ('root'-:2!:5'USER') +. (<2!:5'HOME') e. 0;'/var/root';'/root';'';,'/' do.
     shellcmd ::0: 'find ',dir,' -type d -exec chmod a+rx {} \+'

--- a/jsrc/jeload.c
+++ b/jsrc/jeload.c
@@ -353,6 +353,8 @@ int jefirst(int type,char* arg)
 	strcat(input,"[UNAME_z_=:'Win'");
 #elif defined(__MACH__)
 	strcat(input,"[UNAME_z_=:'Darwin'");
+#elif defined(__OpenBSD__)
+	strcat(input,"[UNAME_z_=:'OpenBSD'");
 #elif !defined(ANDROID)
 	strcat(input,"[UNAME_z_=:'Linux'");
 #endif

--- a/jsrc/jeload.c
+++ b/jsrc/jeload.c
@@ -355,7 +355,7 @@ int jefirst(int type,char* arg)
 	strcat(input,"[UNAME_z_=:'Darwin'");
 #elif defined(__OpenBSD__)
 	strcat(input,"[UNAME_z_=:'OpenBSD'");
-#elif !defined(ANDROID)
+#elif defined(__linux__) && !defined(ANDROID)
 	strcat(input,"[UNAME_z_=:'Linux'");
 #endif
 	if(FHS) strcat(input,"[FHS_z_=:1");

--- a/jsrc/js.h
+++ b/jsrc/js.h
@@ -92,6 +92,7 @@ define one of the following in the build as required
 #define SYS_NETBSD          1048576L        /* GCC                         */
 #define SYS_SUNSOL2         2097152L        /* GCC                         */
 #define SYS_MACOSX          4194304L        /* GCC (CC)                    */
+#define SYS_OPENBSD         8388608L        /* GCC                         */
 
 #define SY_WIN32            0    /* any windows intel Visual Studio        */
 #define SY_WINCE            0    /* any windows ce versions                */
@@ -104,7 +105,8 @@ define one of the following in the build as required
 #define SYS_UNIX            (SYS_ATT3B1 + SYS_DEC5500 + SYS_IBMRS6000 + \
                              SYS_MIPS + SYS_NEXT + SYS_SGI + SYS_SUN3 + \
                              SYS_SUN4 + SYS_VAX + SYS_LINUX + SYS_MACOSX + \
-                             SYS_FREEBSD + SYS_NETBSD + SYS_SUNSOL2 + SYS_HPUX)
+                             SYS_FREEBSD + SYS_NETBSD + SYS_OPENBSD + \
+                             SYS_SUNSOL2 + SYS_HPUX)
 
 #if defined(__FreeBSD__)
 #define SYS SYS_FREEBSD
@@ -112,6 +114,10 @@ define one of the following in the build as required
 
 #if defined(__NetBSD__)
 #define SYS SYS_NETBSD
+#endif
+
+#if defined(__OpenBSD__)
+#define SYS SYS_OPENBSD
 #endif
 
 #if defined(sparc) && ! defined(__svr4__)

--- a/jsrc/jversion-x.h
+++ b/jsrc/jversion-x.h
@@ -9,6 +9,8 @@
 #define jplatform "darwin"
 #elif defined(__linux__)
 #define jplatform "linux"
+#elif defined(__OpenBSD__)
+#define jplatform "openbsd"
 #else
 #define jplatform "unknown"
 #endif

--- a/make2/build_all.sh
+++ b/make2/build_all.sh
@@ -22,6 +22,10 @@ if [ "`uname -m`" = "armv6l" ] || [ "`uname -m`" = "aarch64" ] || [ "$RASPI" = 1
 jplatform="${jplatform:=raspberry}"
 elif [ "`uname`" = "Darwin" ]; then
 jplatform="${jplatform:=darwin}"
+elif [ "`uname`" = "OpenBSD" ]; then
+#jplatform="${jplatform:=openbsd}" # TODO
+jplatform="${jplatform:=linux}"
+make=gmake
 else
 jplatform="${jplatform:=linux}"
 fi
@@ -35,6 +39,8 @@ else
 j64x="${j64x:=j32}"
 fi
 
-jplatform=$jplatform j64x=$j64x ./build_jconsole.sh
-jplatform=$jplatform j64x=$j64x ./build_libj.sh
-jplatform=$jplatform j64x=$j64x ./build_tsdll.sh
+make="${make:=make}"
+
+make=$make jplatform=$jplatform j64x=$j64x ./build_jconsole.sh
+make=$make jplatform=$jplatform j64x=$j64x ./build_libj.sh
+make=$make jplatform=$jplatform j64x=$j64x ./build_tsdll.sh

--- a/make2/build_all.sh
+++ b/make2/build_all.sh
@@ -30,14 +30,15 @@ jplatform="${jplatform:=linux}"
 fi
 if [ "`uname -m`" = "x86_64" ] || [ "`uname -m`" = "amd64" ]; then
 j64x="${j64x:=j64avx}"
-elif [ "`uname -m`" = "aarch64" ]; then
-j64x="${j64x:=j64}"
+elif [ "`uname -m`" = "aarch64" ] || [ "`uname -m`" = "arm64" ]; then
+j64x="${j64x:=j64arm}"
 elif [ "`uname -m`" = "arm64" ] && [ -z "${jplatform##*darwin*}" ]; then
 j64x="${j64x:=j64arm}"
 else
 j64x="${j64x:=j32}"
 fi
 
+echo "jplatform=$jplatform" "j64x=$j64x"
 make="${make:=make}"
 
 make=$make jplatform=$jplatform j64x=$j64x ./build_jconsole.sh

--- a/make2/build_all.sh
+++ b/make2/build_all.sh
@@ -28,7 +28,7 @@ make=gmake
 else
 jplatform="${jplatform:=linux}"
 fi
-if [ "`uname -m`" = "x86_64" ]; then
+if [ "`uname -m`" = "x86_64" ] || [ "`uname -m`" = "amd64" ]; then
 j64x="${j64x:=j64avx}"
 elif [ "`uname -m`" = "aarch64" ]; then
 j64x="${j64x:=j64}"

--- a/make2/build_all.sh
+++ b/make2/build_all.sh
@@ -23,8 +23,7 @@ jplatform="${jplatform:=raspberry}"
 elif [ "`uname`" = "Darwin" ]; then
 jplatform="${jplatform:=darwin}"
 elif [ "`uname`" = "OpenBSD" ]; then
-#jplatform="${jplatform:=openbsd}" # TODO
-jplatform="${jplatform:=linux}"
+jplatform="${jplatform:=openbsd}"
 make=gmake
 else
 jplatform="${jplatform:=linux}"

--- a/make2/build_jconsole.sh
+++ b/make2/build_jconsole.sh
@@ -150,6 +150,18 @@ openbsd_j64arm)
 CFLAGS="$common -march=armv8-a+crc -DRASPI"
 LDFLAGS=" $LDTHREAD"
 ;;
+openbsd_j64)
+CFLAGS="$common"
+LDFLAGS=" $LDTHREAD"
+;;
+openbsd_j64avx)
+CFLAGS="$common"
+LDFLAGS=" $LDTHREAD"
+;;
+openbsd_j64avx2)
+CFLAGS="$common"
+LDFLAGS=" $LDTHREAD"
+;;
 darwin_j32)
 CFLAGS="$common -m32 -msse2 -mfpmath=sse $macmin"
 LDFLAGS=" -ldl $LDTHREAD -m32 $macmin "

--- a/make2/build_jconsole.sh
+++ b/make2/build_jconsole.sh
@@ -27,8 +27,8 @@ jplatform="${jplatform:=linux}"
 fi
 if [ "`uname -m`" = "x86_64" ] || [ "`uname -m`" = "amd64" ]; then
 j64x="${j64x:=j64avx}"
-elif [ "`uname -m`" = "aarch64" ]; then
-j64x="${j64x:=j64}"
+elif [ "`uname -m`" = "aarch64" ] || [ "`uname -m`" = "arm64" ]; then
+j64x="${j64x:=j64arm}"
 elif [ "`uname -m`" = "arm64" ] && [ -z "${jplatform##*darwin*}" ]; then
 j64x="${j64x:=j64arm}"
 else

--- a/make2/build_jconsole.sh
+++ b/make2/build_jconsole.sh
@@ -146,6 +146,10 @@ raspberry_j64)
 CFLAGS="$common -march=armv8-a+crc -DRASPI"
 LDFLAGS=" -ldl $LDTHREAD"
 ;;
+openbsd_j64arm)
+CFLAGS="$common -march=armv8-a+crc -DRASPI"
+LDFLAGS=" $LDTHREAD"
+;;
 darwin_j32)
 CFLAGS="$common -m32 -msse2 -mfpmath=sse $macmin"
 LDFLAGS=" -ldl $LDTHREAD -m32 $macmin "

--- a/make2/build_jconsole.sh
+++ b/make2/build_jconsole.sh
@@ -203,5 +203,5 @@ mkdir -p obj/$jplatform/$j64x/
 cp makefile-jconsole obj/$jplatform/$j64x/.
 export CFLAGS LDFLAGS TARGET OBJSLN jplatform j64x
 cd obj/$jplatform/$j64x/
-make -f makefile-jconsole
+$make -f makefile-jconsole
 cd -

--- a/make2/build_jconsole.sh
+++ b/make2/build_jconsole.sh
@@ -19,10 +19,13 @@ if [ "`uname -m`" = "armv6l" ] || [ "`uname -m`" = "aarch64" ] || [ "$RASPI" = 1
 jplatform="${jplatform:=raspberry}"
 elif [ "`uname`" = "Darwin" ]; then
 jplatform="${jplatform:=darwin}"
+elif [ "`uname`" = "OpenBSD" ]; then
+jplatform="${jplatform:=openbsd}"
+make=gmake
 else
 jplatform="${jplatform:=linux}"
 fi
-if [ "`uname -m`" = "x86_64" ]; then
+if [ "`uname -m`" = "x86_64" ] || [ "`uname -m`" = "amd64" ]; then
 j64x="${j64x:=j64avx}"
 elif [ "`uname -m`" = "aarch64" ]; then
 j64x="${j64x:=j64}"
@@ -208,6 +211,7 @@ echo no case for those parameters
 exit
 esac
 
+make="${make:=make}"
 echo "CFLAGS=$CFLAGS"
 
 if [ ! -f ../jsrc/jversion.h ] ; then

--- a/make2/build_jnative.sh
+++ b/make2/build_jnative.sh
@@ -142,6 +142,11 @@ TARGET=libjnative.so
 CFLAGS="$common -march=armv8-a+crc -I$JAVA_HOME/include -I$JAVA_HOME/include/linux "
 LDFLAGS=" -shared -Wl,-soname,libjnative.so "
 ;;
+openbsd_j64arm)
+TARGET=libjnative.so
+CFLAGS="$common -march=armv8-a+crc -I$JAVA_HOME/include -I$JAVA_HOME/include/linux "
+LDFLAGS=" -shared -Wl,-soname,libjnative.so "
+;;
 darwin_j32)
 TARGET=libjnative.dylib
 CFLAGS="$common -m32 -msse2 -mfpmath=sse $macmin -I$JAVA_HOME/include -I$JAVA_HOME/include/darwin "

--- a/make2/build_jnative.sh
+++ b/make2/build_jnative.sh
@@ -147,6 +147,21 @@ TARGET=libjnative.so
 CFLAGS="$common -march=armv8-a+crc -I$JAVA_HOME/include -I$JAVA_HOME/include/linux "
 LDFLAGS=" -shared -Wl,-soname,libjnative.so "
 ;;
+openbsd_j64)
+TARGET=libjnative.so
+CFLAGS="$common -I$JAVA_HOME/include -I$JAVA_HOME/include/openbsd "
+LDFLAGS=" -shared -Wl,-soname,libjnative.so "
+;;
+openbsd_j64avx)
+TARGET=libjnative.so
+CFLAGS="$common -I$JAVA_HOME/include -I$JAVA_HOME/include/openbsd "
+LDFLAGS=" -shared -Wl,-soname,libjnative.so "
+;;
+openbsd_j64avx2)
+TARGET=libjnative.so
+CFLAGS="$common -I$JAVA_HOME/include -I$JAVA_HOME/include/openbsd "
+LDFLAGS=" -shared -Wl,-soname,libjnative.so "
+;;
 darwin_j32)
 TARGET=libjnative.dylib
 CFLAGS="$common -m32 -msse2 -mfpmath=sse $macmin -I$JAVA_HOME/include -I$JAVA_HOME/include/darwin "

--- a/make2/build_jnative.sh
+++ b/make2/build_jnative.sh
@@ -19,10 +19,13 @@ if [ "`uname -m`" = "armv6l" ] || [ "`uname -m`" = "aarch64" ] || [ "$RASPI" = 1
 jplatform="${jplatform:=raspberry}"
 elif [ "`uname`" = "Darwin" ]; then
 jplatform="${jplatform:=darwin}"
+elif [ "`uname`" = "OpenBSD" ]; then
+jplatform="${jplatform:=openbsd}"
+make=gmake
 else
 jplatform="${jplatform:=linux}"
 fi
-if [ "`uname -m`" = "x86_64" ]; then
+if [ "`uname -m`" = "x86_64" ] || [ "`uname -m`" = "amd64" ]; then
 j64x="${j64x:=j64avx}"
 elif [ "`uname -m`" = "aarch64" ]; then
 j64x="${j64x:=j64}"
@@ -192,6 +195,7 @@ echo no case for those parameters
 exit
 esac
 
+make="${make:=make}"
 echo "CFLAGS=$CFLAGS"
 
 mkdir -p ../bin/$jplatform/$j64x
@@ -199,5 +203,5 @@ mkdir -p obj/$jplatform/$j64x/
 cp makefile-jnative obj/$jplatform/$j64x/.
 export CFLAGS LDFLAGS TARGET jplatform j64x
 cd obj/$jplatform/$j64x/
-make -f makefile-jnative
+$make -f makefile-jnative
 cd -

--- a/make2/build_jnative.sh
+++ b/make2/build_jnative.sh
@@ -27,8 +27,8 @@ jplatform="${jplatform:=linux}"
 fi
 if [ "`uname -m`" = "x86_64" ] || [ "`uname -m`" = "amd64" ]; then
 j64x="${j64x:=j64avx}"
-elif [ "`uname -m`" = "aarch64" ]; then
-j64x="${j64x:=j64}"
+elif [ "`uname -m`" = "aarch64" ] || [ "`uname -m`" = "arm64" ]; then
+j64x="${j64x:=j64arm}"
 elif [ "`uname -m`" = "arm64" ] && [ -z "${jplatform##*darwin*}" ]; then
 j64x="${j64x:=j64arm}"
 else

--- a/make2/build_libj.sh
+++ b/make2/build_libj.sh
@@ -19,10 +19,13 @@ if [ "`uname -m`" = "armv6l" ] || [ "`uname -m`" = "aarch64" ] || [ "$RASPI" = 1
 jplatform="${jplatform:=raspberry}"
 elif [ "`uname`" = "Darwin" ]; then
 jplatform="${jplatform:=darwin}"
+elif [ "`uname`" = "OpenBSD" ]; then
+jplatform="${jplatform:=openbsd}"
+make=gmake
 else
 jplatform="${jplatform:=linux}"
 fi
-if [ "`uname -m`" = "x86_64" ]; then
+if [ "`uname -m`" = "x86_64" ] || [ "`uname -m`" = "amd64" ]; then
 j64x="${j64x:=j64avx}"
 elif [ "`uname -m`" = "aarch64" ]; then
 j64x="${j64x:=j64}"
@@ -541,6 +544,7 @@ OBJS_SLEEF=" \
 fi
 fi
 
+make="${make:=make}"
 echo "CFLAGS=$CFLAGS"
 
 if [ ! -f ../jsrc/jversion.h ] ; then

--- a/make2/build_libj.sh
+++ b/make2/build_libj.sh
@@ -325,6 +325,43 @@ FLAGS_SLEEF=" -DENABLE_ADVSIMD "
 FLAGS_BASE64=""
 ;;
 
+openbsd_j64) # openbsd intel 64bit nonavx
+TARGET=libj.so
+CFLAGS="$common -msse3 "
+LDFLAGS=" -shared -Wl,-soname,libj.so -lm $LDOPENMP $LDTHREAD"
+OBJS_AESNI=" aes-ni.o "
+SRC_ASM="${SRC_ASM_openbsd}"
+GASM_FLAGS=""
+FLAGS_SLEEF=" -DENABLE_SSE2 "
+FLAGS_BASE64=""
+;;
+
+openbsd_j64avx) # openbsd intel 64bit avx
+TARGET=libj.so
+CFLAGS="$common -DC_AVX=1 "
+LDFLAGS=" -shared -Wl,-soname,libj.so -lm $LDOPENMP $LDTHREAD"
+CFLAGS_SIMD=" -mavx "
+OBJS_FMA=" gemm_int-fma.o "
+OBJS_AESNI=" aes-ni.o "
+SRC_ASM="${SRC_ASM_openbsd}"
+GASM_FLAGS=""
+FLAGS_SLEEF=" -DENABLE_AVX "
+FLAGS_BASE64=" -DHAVE_SSSE3=1 -DHAVE_AVX=1 "
+;;
+
+openbsd_j64avx2) # openbsd intel 64bit avx2
+TARGET=libj.so
+CFLAGS="$common -DC_AVX=1 -DC_AVX2=1 "
+LDFLAGS=" -shared -Wl,-soname,libj.so -lm $LDOPENMP $LDTHREAD"
+CFLAGS_SIMD=" -march=haswell -mavx2 -mfma -mbmi -mbmi2 -mlzcnt -mmovbe -mpopcnt "
+OBJS_FMA=" gemm_int-fma.o "
+OBJS_AESNI=" aes-ni.o "
+SRC_ASM="${SRC_ASM_openbsd}"
+GASM_FLAGS=""
+FLAGS_SLEEF=" -DENABLE_AVX2 "
+FLAGS_BASE64=" -DHAVE_AVX2=1 "
+;;
+
 darwin_j32) # darwin x86
 TARGET=libj.dylib
 CFLAGS="$common -m32 -msse2 -mfpmath=sse $macmin"

--- a/make2/build_libj.sh
+++ b/make2/build_libj.sh
@@ -27,8 +27,8 @@ jplatform="${jplatform:=linux}"
 fi
 if [ "`uname -m`" = "x86_64" ] || [ "`uname -m`" = "amd64" ]; then
 j64x="${j64x:=j64avx}"
-elif [ "`uname -m`" = "aarch64" ]; then
-j64x="${j64x:=j64}"
+elif [ "`uname -m`" = "aarch64" ] || [ "`uname -m`" = "arm64" ]; then
+j64x="${j64x:=j64arm}"
 elif [ "`uname -m`" = "arm64" ] && [ -z "${jplatform##*darwin*}" ]; then
 j64x="${j64x:=j64arm}"
 else

--- a/make2/build_libj.sh
+++ b/make2/build_libj.sh
@@ -313,6 +313,18 @@ FLAGS_SLEEF=" -DENABLE_ADVSIMD "
 FLAGS_BASE64=" -DHAVE_NEON64=1 "
 ;;
 
+openbsd_j64arm)
+TARGET=libj.so
+CFLAGS="$common -march=armv8-a+crc -DRASPI -DC_CRC32C=1 "
+LDFLAGS=" -shared -Wl,-soname,libj.so -lm $LDOPENMP $LDTHREAD"
+OBJS_AESARM=" aes-arm.o "
+SRC_ASM="${SRC_ASM_RASPI}"
+GASM_FLAGS=""
+FLAGS_SLEEF=" -DENABLE_ADVSIMD "
+#FLAGS_BASE64=" -DHAVE_NEON64=1 " # TODO
+FLAGS_BASE64=""
+;;
+
 darwin_j32) # darwin x86
 TARGET=libj.dylib
 CFLAGS="$common -m32 -msse2 -mfpmath=sse $macmin"

--- a/make2/build_libj.sh
+++ b/make2/build_libj.sh
@@ -503,5 +503,5 @@ mkdir -p obj/$jplatform/$j64x/
 cp makefile-libj obj/$jplatform/$j64x/.
 export CFLAGS LDFLAGS TARGET CFLAGS_SIMD GASM_FLAGS FLAGS_SLEEF FLAGS_BASE64 DLLOBJS LIBJDEF LIBJRES OBJS_BASE64 OBJS_FMA OBJS_AESNI OBJS_AESARM OBJS_SLEEF OBJS_ASM SRC_ASM jplatform j64x
 cd obj/$jplatform/$j64x/
-make -f makefile-libj
+$make -f makefile-libj
 cd -

--- a/make2/build_tsdll.sh
+++ b/make2/build_tsdll.sh
@@ -194,5 +194,5 @@ mkdir -p obj/$jplatform/$j64x/
 cp makefile-tsdll obj/$jplatform/$j64x/.
 export CFLAGS LDFLAGS TARGET jplatform j64x
 cd obj/$jplatform/$j64x/
-make -f makefile-tsdll
+$make -f makefile-tsdll
 cd -

--- a/make2/build_tsdll.sh
+++ b/make2/build_tsdll.sh
@@ -27,8 +27,8 @@ jplatform="${jplatform:=linux}"
 fi
 if [ "`uname -m`" = "x86_64" ] || [ "`uname -m`" = "amd64" ]; then
 j64x="${j64x:=j64avx}"
-elif [ "`uname -m`" = "aarch64" ]; then
-j64x="${j64x:=j64}"
+elif [ "`uname -m`" = "aarch64" ] || [ "`uname -m`" = "arm64" ]; then
+j64x="${j64x:=j64arm}"
 elif [ "`uname -m`" = "arm64" ] && [ -z "${jplatform##*darwin*}" ]; then
 j64x="${j64x:=j64arm}"
 else

--- a/make2/build_tsdll.sh
+++ b/make2/build_tsdll.sh
@@ -152,6 +152,12 @@ CFLAGS="$common -march=armv8-a+crc -DRASPI "
 LDFLAGS=" -shared -Wl,-soname,libtsdll.so -lm -ldl"
 ;;
 
+openbsd_j64arm)
+TARGET=libtsdll.so
+CFLAGS="$common -march=armv8-a+crc -DRASPI "
+LDFLAGS=" -shared -Wl,-soname,libtsdll.so -lm"
+;;
+
 darwin_j32) # darwin x86
 TARGET=libtsdll.dylib
 CFLAGS="$common -m32 -msse2 -mfpmath=sse $macmin"

--- a/make2/build_tsdll.sh
+++ b/make2/build_tsdll.sh
@@ -158,6 +158,24 @@ CFLAGS="$common -march=armv8-a+crc -DRASPI "
 LDFLAGS=" -shared -Wl,-soname,libtsdll.so -lm"
 ;;
 
+openbsd_j64) # openbsd intel 64bit nonavx
+TARGET=libtsdll.so
+CFLAGS="$common "
+LDFLAGS=" -shared -Wl,-soname,libtsdll.so -lm"
+;;
+
+openbsd_j64avx) # openbsd intel 64bit avx
+TARGET=libtsdll.so
+CFLAGS="$common "
+LDFLAGS=" -shared -Wl,-soname,libtsdll.so -lm"
+;;
+
+openbsd_j64avx2) # openbsd intel 64bit avx
+TARGET=libtsdll.so
+CFLAGS="$common "
+LDFLAGS=" -shared -Wl,-soname,libtsdll.so -lm"
+;;
+
 darwin_j32) # darwin x86
 TARGET=libtsdll.dylib
 CFLAGS="$common -m32 -msse2 -mfpmath=sse $macmin"

--- a/make2/build_tsdll.sh
+++ b/make2/build_tsdll.sh
@@ -19,10 +19,13 @@ if [ "`uname -m`" = "armv6l" ] || [ "`uname -m`" = "aarch64" ] || [ "$RASPI" = 1
 jplatform="${jplatform:=raspberry}"
 elif [ "`uname`" = "Darwin" ]; then
 jplatform="${jplatform:=darwin}"
+elif [ "`uname`" = "OpenBSD" ]; then
+jplatform="${jplatform:=openbsd}"
+make=gmake
 else
 jplatform="${jplatform:=linux}"
 fi
-if [ "`uname -m`" = "x86_64" ]; then
+if [ "`uname -m`" = "x86_64" ] || [ "`uname -m`" = "amd64" ]; then
 j64x="${j64x:=j64avx}"
 elif [ "`uname -m`" = "aarch64" ]; then
 j64x="${j64x:=j64}"
@@ -211,6 +214,7 @@ echo no case for those parameters
 exit
 esac
 
+make="${make:=make}"
 echo "CFLAGS=$CFLAGS"
 
 mkdir -p ../bin/$jplatform/$j64x

--- a/make2/cpbin.sh
+++ b/make2/cpbin.sh
@@ -23,6 +23,8 @@ if [ "`uname -m`" = "armv6l" ] || [ "`uname -m`" = "aarch64" ] || [ "$RASPI" = 1
 jplatform="${jplatform:=raspberry}"
 elif [ "`uname`" = "Darwin" ]; then
 jplatform="${jplatform:=darwin}"
+elif [ "`uname`" = "OpenBSD" ]; then
+jplatform="${jplatform:=openbsd}"
 else
 jplatform="${jplatform:=linux}"
 fi

--- a/script/run_tests.ijs
+++ b/script/run_tests.ijs
@@ -5,7 +5,7 @@ NB. todo - macos and windows
 
 3 : 0''
 select. UNAME
-case. 'Linux' do.
+case. 'Linux';'OpenBSD' do.
  j=:     'libj.so'
  javx=:  'libjavx.so'
  javx2=: 'libjavx2.so'

--- a/script/testga.ijs
+++ b/script/testga.ijs
@@ -3,7 +3,7 @@
 
 testpath=: (1!:43''),'/test/'
 
-os=. (('Linux';'Darwin') i. <UNAME) pick ;:'linux darwin win'
+os=. (('Linux';'Darwin';'OpenBSD') i. <UNAME) pick ;:'linux darwin openbsd win'
 testres=: 'test',os,'.txt'
 
 0!:0 <testpath,'tsu.ijs'


### PR DESCRIPTION
Recently Brian Callahan made a J port for OpenBSD amd64: https://briancallahan.net/blog/20210911.html
The details of his port patches are here: https://marc.info/?l=openbsd-ports&m=163138993214367&w=2

I thought it would be nice for the main J repo to build on OpenBSD out of the box without patches required.
This has been tested on an Intel i7-1165G7 laptop (Lemur Pro lemp10) and a Raspberry Pi 4 8GB both running OpenBSD 7.0 (CURRENT snapshots).

As mentioned in the commit messages a fair few of the tsu.ijs tests succeed but both architectures crash during or just after g128x7.ijs.  Brian Callahan mentions in his post that the gss.ijs test fails for him with his port.

I've attempted to follow the existing code style in the build scripts even though there's a little bit of repetition.
Are there any changes or cleanup required to get this merged?