### PR TITLE
clang detection should not depend on spelling of cc

### DIFF
--- a/make2/build_jconsole.sh
+++ b/make2/build_jconsole.sh
@@ -63,7 +63,7 @@ compiler=$(readlink -f $(command -v $CC) 2> /dev/null || echo $CC)
 echo "CC=$CC"
 echo "compiler=$compiler"
 
-if [ -z "${compiler##*gcc*}" ] || [ -z "${CC##*gcc*}" ]; then
+if ! $CC --version | grep clang >/dev/null; then
 # gcc
 common="$OPENMP -fPIC -O2 -fvisibility=hidden -fno-strict-aliasing  \
  -Werror -Wextra -Wno-unknown-warning-option \

--- a/make2/build_jnative.sh
+++ b/make2/build_jnative.sh
@@ -62,7 +62,7 @@ compiler=$(readlink -f $(command -v $CC) 2> /dev/null || echo $CC)
 echo "CC=$CC"
 echo "compiler=$compiler"
 
-if [ -z "${compiler##*gcc*}" ] || [ -z "${CC##*gcc*}" ]; then
+if ! $CC --version | grep clang >/dev/null; then
 # gcc
 common="$OPENMP -fPIC -O2 -fvisibility=hidden -fno-strict-aliasing  \
  -Werror -Wextra -Wno-unknown-warning-option \

--- a/make2/build_libj.sh
+++ b/make2/build_libj.sh
@@ -90,7 +90,7 @@ fi
 fi
 fi
 
-if [ -z "${compiler##*gcc*}" ] || [ -z "${CC##*gcc*}" ]; then
+if ! $CC --version | grep clang >/dev/null; then
 # gcc
 common="$OPENMP -fPIC -O2 -fvisibility=hidden -fno-strict-aliasing -fno-stack-protector  \
  -Werror -Wextra -Wno-unknown-warning-option \

--- a/make2/build_tsdll.sh
+++ b/make2/build_tsdll.sh
@@ -62,7 +62,7 @@ compiler=$(readlink -f $(command -v $CC) 2> /dev/null || echo $CC)
 echo "CC=$CC"
 echo "compiler=$compiler"
 
-if [ -z "${compiler##*gcc*}" ] || [ -z "${CC##*gcc*}" ]; then
+if ! $CC --version | grep clang >/dev/null; then
 # gcc
 common="$OPENMP -fPIC -O2 -fvisibility=hidden -fno-strict-aliasing  \
  -Werror -Wextra -Wno-unknown-warning-option \


### PR DESCRIPTION
We can detect clang using

   $(CC) --version | grep clang 

This works even when CC=/usr/bin/cc regardless of whether /usr/bin/cc is gcc or clang.