### PR TITLE
Fix GCC builds by correcting the order of calloc arguments.

### DIFF
--- a/jsrc/linenoise.c
+++ b/jsrc/linenoise.c
@@ -2955,7 +2955,7 @@ notinserted:
         return 0;
     }
     if (history == NULL) {
-        history = (char **)calloc(sizeof(char*), history_max_len);
+        history = (char **)calloc(history_max_len, sizeof(char*));
     }
 
     /* do not insert duplicate lines into history */
@@ -2988,7 +2988,7 @@ int linenoiseHistorySetMaxLen(int len) {
     if (history) {
         int tocopy = history_len;
 
-        newHistory = (char **)calloc(sizeof(char*), len);
+        newHistory = (char **)calloc(len, sizeof(char*));
 
         /* If we can't copy everything, free the elements we'll not use. */
         if (len < tocopy) {


### PR DESCRIPTION
Downloading and building the source as-is on Arch Linux with GCC version `gcc (GCC) 14.1.1 20240522` fails, giving the following error:

```
../../../../jsrc/linenoise.c: In function ‘linenoiseHistoryAddAllocated’:
../../../../jsrc/linenoise.c:2958:42: error: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
 2958 |         history = (char **)calloc(sizeof(char*), history_max_len);
      |                                          ^~~~
../../../../jsrc/linenoise.c:2958:42: note: earlier argument should specify number of elements, later size of each element
../../../../jsrc/linenoise.c: In function ‘linenoiseHistorySetMaxLen’:
../../../../jsrc/linenoise.c:2991:45: error: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
 2991 |         newHistory = (char **)calloc(sizeof(char*), len);
      |                                             ^~~~
../../../../jsrc/linenoise.c:2991:45: note: earlier argument should specify number of elements, later size of each element
At top level:
```

Technically this violates the definition of `calloc`. The first argument is defined as the number of elements while the second is the byte length of those elements.