### PR TITLE
Copies libgmp.dylib from mpir to jlibrary/bin on cpbin.sh

### DIFF
--- a/make2/cpbin.sh
+++ b/make2/cpbin.sh
@@ -59,6 +59,9 @@ echo \# jplatform $jplatform
 
 if [ $jplatform = "darwin" ]; then
 
+# copy libgmp to bin
+cp ../mpir/apple/macos/libgmp.dylib ../jlibrary/bin/libgmp.dylib
+
 # macos 64-bit
 if [ -f "../bin/${jplatform}/j64$DEBUGDIR/jconsole" ] && [ -f "../bin/${jplatform}/j64arm$DEBUGDIR/jconsole" ]; then
 # fat binary


### PR DESCRIPTION
Currently you have to copy libgmp.dylib manually to jlibrary/bin to run the tests. This fixes that.