### PR TITLE
🐛 Fix warning from strchr return value assignment

### DIFF
--- a/jsrc/io.c
+++ b/jsrc/io.c
@@ -901,8 +901,8 @@ const char *sym_name = "JGetLocale";
   Dl_info info;
   if (dladdr(sym_ptr,&info)){ // non-zero is success
    strcpy(path,info.dli_fname);
-   char *p1;
-   if((p1=strrchr(info.dli_fname,filesep))){path[p1-(char*)info.dli_fname]=0;}
+   const char *p1;
+   if((p1=strrchr(info.dli_fname,filesep))){path[p1-info.dli_fname]=0;}
   } else *path=0;
  } else *path=0;
 #endif


### PR DESCRIPTION
The strchr in C is originally documented to return a char* value but this changed in ISO C23.  Now the default is to use a type-generic function macro which returns the const-ness according to the parameter type.  This is the default for gcc 16.

This patch changes the local variable type and also removes the now unnecessary cast in the following expression.